### PR TITLE
Try rendering markdown index files

### DIFF
--- a/contentLoader.js
+++ b/contentLoader.js
@@ -296,7 +296,9 @@ async function resolveFileInArchive (archive, path) {
 const CHECK_PATHS = [
   (path) => path,
   (path) => path + `index.html`,
+  (path) => path + `index.md`,
   (path) => path + `/index.html`,
+  (path) => path + `/index.md`,
   (path) => path + `.html`,
   (path) => path + `.md`,
 ]


### PR DESCRIPTION
This aligns the loader with Beaker Browser's behavior.

Or at least I think it does. I found `index.md` in the `view-source.js` page for Beaker, but I don't know where their directory rendering logic lives.

https://github.com/beakerbrowser/beaker/blob/b951fa610ba89d5e987d96a3182e9c6360a6f09e/app/builtin-pages/views/view-source.js#L46-L47